### PR TITLE
SEO completo y reparación del deploy al repo espejo

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,11 +24,16 @@ jobs:
 
       - name: Sync files
         run: |
-          rsync -av --delete --exclude '.git' ./ deploy/
+          # 'deploy' se excluye para no copiar el destino dentro de sí mismo:
+          # sin la exclusión, rsync entra en recursión, los archivos "desaparecen"
+          # a mitad de la copia y el paso truena con código 24.
+          rsync -a --delete --exclude '.git' --exclude 'deploy' ./ deploy/
+          # limpia copias anidadas que dejaron corridas anteriores del bug
+          rm -rf deploy/deploy
           cd deploy
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
-          git add .
+          git add -A
           git commit -m "Sync from SEITC-MTY" || echo "No changes to commit"
           git push origin main
           

--- a/src/app/(pages)/eventos/page.tsx
+++ b/src/app/(pages)/eventos/page.tsx
@@ -4,7 +4,21 @@ import Events from 'seitc/app/components/events/Events';
 export const metadata: Metadata = {
   title: 'Eventos',
   description:
-    'Talleres, charlas con la industria y eventos de comunidad de SEITC. Calendario del semestre y eventos pasados.',
+    'Talleres, charlas con la industria y eventos de comunidad de SEITC en el Tec de Monterrey, Campus Monterrey. Calendario del semestre y eventos pasados, organizados por la Dirección de Proyectos.',
+  keywords: [
+    'eventos SEITC',
+    'eventos ITC Tec de Monterrey',
+    'talleres de programación Monterrey',
+    'Leetcode Tec de Monterrey',
+    'Prep to Intern',
+    'Dirección de Proyectos SEITC',
+    'Armando Javier Flores Salazar',
+  ],
+  openGraph: {
+    title: 'Eventos | SEITC',
+    description:
+      'Calendario de talleres, charlas con la industria y comunidad de la Sociedad de Estudiantes de ITC.',
+  },
 };
 
 export default function EventosPage() {

--- a/src/app/(pages)/integrantes/page.tsx
+++ b/src/app/(pages)/integrantes/page.tsx
@@ -4,9 +4,56 @@ import Integrantes from "seitc/app/components/integrantes/Integrantes";
 export const metadata: Metadata = {
   title: "Integrantes",
   description:
-    "La mesa directiva de SEITC en la gestión 2026-2027 y las gestiones anteriores.",
+    "La mesa directiva de SEITC en la gestión 2026-2027: Juan Antonio Rodríguez Reyna (Presidencia), Iván Gabriel Espinosa García (Vicepresidencia), Armando Javier Flores Salazar (Dirección de Proyectos) y el resto del equipo, junto con las gestiones anteriores.",
+  keywords: [
+    "mesa directiva SEITC",
+    "Juan Antonio Rodríguez Reyna",
+    "Iván Gabriel Espinosa García",
+    "Armando Javier Flores Salazar",
+    "Mariano Guerrero Flores",
+    "Director de Proyectos",
+    "SEITC Tec de Monterrey",
+  ],
+  openGraph: {
+    title: "Integrantes | SEITC",
+    description:
+      "Conoce a la mesa directiva 2026-2027 de la Sociedad de Estudiantes de Ingeniería en Tecnologías Computacionales.",
+  },
+};
+
+/* Perfil estructurado del Director de Proyectos (autor y responsable del sitio),
+   enlazado con sus otros proyectos públicos. */
+const personStructuredData = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  "@id": "https://seitc.com.mx/#armando-flores",
+  name: "Armando Javier Flores Salazar",
+  jobTitle: "Director de Proyectos",
+  memberOf: {
+    "@type": "Organization",
+    name: "SEITC, Sociedad de Estudiantes de Ingeniería en Tecnologías Computacionales",
+    url: "https://seitc.com.mx",
+  },
+  affiliation: {
+    "@type": "CollegeOrUniversity",
+    name: "Tecnológico de Monterrey, Campus Monterrey",
+  },
+  url: "https://auctorum.com.mx/about",
+  sameAs: [
+    "https://auctorum.com.mx",
+    "https://auctorum.com.mx/about",
+    "https://github.com/cocopsn",
+  ],
 };
 
 export default function IntegrantesPage() {
-  return <Integrantes />;
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(personStructuredData) }}
+      />
+      <Integrantes />
+    </>
+  );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,16 +10,120 @@ const archivo = Archivo({
   display: "swap",
 });
 
+const SITE_URL = "https://seitc.com.mx";
+const SITE_DESCRIPTION =
+  "Sociedad de Estudiantes de Ingeniería en Tecnologías Computacionales del Tecnológico de Monterrey, Campus Monterrey. Talleres, charlas con la industria y comunidad para la carrera de ITC.";
+
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: {
     default: "SEITC | Sociedad de Estudiantes de ITC, Tec de Monterrey",
     template: "%s | SEITC",
   },
-  description:
-    "Sociedad de Estudiantes de Ingeniería en Tecnologías Computacionales del Tecnológico de Monterrey, Campus Monterrey.",
+  description: SITE_DESCRIPTION,
+  keywords: [
+    "SEITC",
+    "Sociedad de Estudiantes de Ingeniería en Tecnologías Computacionales",
+    "ITC",
+    "Ingeniería en Tecnologías Computacionales",
+    "Tec de Monterrey",
+    "Tecnológico de Monterrey",
+    "Campus Monterrey",
+    "sociedad de alumnos",
+    "grupo estudiantil",
+    "Armando Javier Flores Salazar",
+  ],
+  authors: [
+    { name: "SEITC" },
+    { name: "Armando Javier Flores Salazar", url: "https://auctorum.com.mx/about" },
+  ],
+  creator: "Armando Javier Flores Salazar",
+  publisher: "SEITC, Tecnológico de Monterrey Campus Monterrey",
+  alternates: {
+    canonical: "./",
+  },
+  openGraph: {
+    type: "website",
+    locale: "es_MX",
+    url: SITE_URL,
+    siteName: "SEITC",
+    title: "SEITC | Sociedad de Estudiantes de ITC, Tec de Monterrey",
+    description: SITE_DESCRIPTION,
+    images: [
+      {
+        url: "/images/Toma-Protesta.jpeg",
+        alt: "Mesa directiva de SEITC en la toma de protesta",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "SEITC | Sociedad de Estudiantes de ITC, Tec de Monterrey",
+    description: SITE_DESCRIPTION,
+    images: ["/images/Toma-Protesta.jpeg"],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+    },
+  },
   icons: {
     icon: "/favicon.ico",
   },
+};
+
+/* Datos estructurados del sitio: la organización (con su mesa directiva) y el
+   sitio web. Solo información pública que ya aparece en las páginas. */
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": `${SITE_URL}/#organizacion`,
+      name: "SEITC",
+      alternateName:
+        "Sociedad de Estudiantes de Ingeniería en Tecnologías Computacionales",
+      url: SITE_URL,
+      logo: `${SITE_URL}/images/Logo128x128.png`,
+      description: SITE_DESCRIPTION,
+      sameAs: [
+        "https://www.facebook.com/share/1D97vBEgLj/?mibextid=wwXIfr",
+        "https://www.tiktok.com/@seitc.mty",
+        "https://www.linkedin.com/company/seitc/",
+        "https://www.instagram.com/seitc.mty/",
+      ],
+      member: [
+        { "@type": "Person", name: "Juan Antonio Rodríguez Reyna", jobTitle: "Presidencia" },
+        { "@type": "Person", name: "Iván Gabriel Espinosa García", jobTitle: "Vicepresidencia" },
+        {
+          "@type": "Person",
+          "@id": `${SITE_URL}/#armando-flores`,
+          name: "Armando Javier Flores Salazar",
+          jobTitle: "Director de Proyectos",
+          url: "https://auctorum.com.mx/about",
+          sameAs: ["https://auctorum.com.mx", "https://github.com/cocopsn"],
+        },
+        { "@type": "Person", name: "Mariano Guerrero Flores", jobTitle: "Dirección de Finanzas" },
+        { "@type": "Person", name: "Mario Giovanni González López", jobTitle: "Dirección de Responsabilidad Social" },
+        { "@type": "Person", name: "Ana Elisa Celaya Montalvo", jobTitle: "Dirección de Comunicación" },
+        { "@type": "Person", name: "Daniella Vázquez Esparza", jobTitle: "Dirección de Vinculación" },
+        { "@type": "Person", name: "Leonel Francisco Bailón Sifuentes", jobTitle: "Dirección de Educación" },
+      ],
+    },
+    {
+      "@type": "WebSite",
+      "@id": `${SITE_URL}/#sitio`,
+      url: SITE_URL,
+      name: "SEITC",
+      inLanguage: "es-MX",
+      publisher: { "@id": `${SITE_URL}/#organizacion` },
+    },
+  ],
 };
 
 export default function RootLayout({
@@ -30,6 +134,10 @@ export default function RootLayout({
   return (
     <html lang="es">
       <body suppressHydrationWarning className={`${archivo.variable} antialiased bg-white`}>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+        />
         <Navbar />
         <main>{children}</main>
         <Footer />

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: 'https://seitc.com.mx/sitemap.xml',
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,27 @@
+import type { MetadataRoute } from 'next';
+
+const BASE = 'https://seitc.com.mx';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const lastModified = new Date();
+  return [
+    {
+      url: BASE,
+      lastModified,
+      changeFrequency: 'weekly',
+      priority: 1,
+    },
+    {
+      url: `${BASE}/eventos`,
+      lastModified,
+      changeFrequency: 'weekly',
+      priority: 0.9,
+    },
+    {
+      url: `${BASE}/integrantes`,
+      lastModified,
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+  ];
+}


### PR DESCRIPTION
Sitemap y robots nativos, metadatos completos (Open Graph, Twitter, canonical, keywords), datos estructurados schema.org (Organization con la mesa directiva, WebSite y perfil Person del Director de Proyectos enlazado con auctorum.com.mx y GitHub).

Reparación del workflow de despliegue: el rsync copiaba la carpeta destino dentro de sí misma; con el peso actual del repo tronaba con código 24 y el espejo seitcMty/seitc-webpage dejó de recibir main. Se excluye el destino y se limpian las copias anidadas de corridas anteriores.

Verificado localmente sobre el build de producción: robots.txt, sitemap.xml con las 3 rutas, los 2 bloques JSON-LD y los metadatos por página presentes en el HTML servido.